### PR TITLE
Replaced destructor with Dispose(), and added InvalidOperationExcept…

### DIFF
--- a/ViscaLibrary/ViscaProtocolProcessor.cs
+++ b/ViscaLibrary/ViscaProtocolProcessor.cs
@@ -44,7 +44,7 @@ namespace Visca
     }
 #endif
 
-    public class ViscaProtocolProcessor
+    public class ViscaProtocolProcessor : IDisposable
     {
         private readonly Dictionary<ViscaCameraId, ViscaCamera> _cameras = new Dictionary<ViscaCameraId, ViscaCamera>(7);
 
@@ -118,13 +118,13 @@ namespace Visca
 #endif
         }
 
-#if !SSHARP
-        ~ViscaProtocolProcessor()
+        public void Dispose()
         {
+#if !SSHARP
             _responseQueue.CompleteAdding();
             _responseQueueCancel.Cancel(false);
-        }
 #endif
+        }
 
         /// <summary>
         /// Commands in the sending queue
@@ -322,6 +322,11 @@ namespace Visca
                 catch (OperationCanceledException)
                 {
                     logMessage(2, "Visca Response Queue shutdown");
+                    break;
+                }
+                catch (InvalidOperationException)
+                {
+                    logMessage(2, "Visca Response Queue shutdown 2");
                     break;
                 }
 #endif


### PR DESCRIPTION
In trying to use this library (in a windows Forms app) It hung on exit. 

I determined that ViscaProtocolProcesser was blocked on close by the parseResponse thread that the destructor would have cancelled.

I was able to solve the issue by change the destructor to Dispose().

Once that was done, it failed with an InvalidOperationException. The OperationCancelledException was apparently changed to an invalid operation by an intervening object. Rather than mess with deeper code, I added a handler as a temporary solution for my problem.

I hope this is helpful.